### PR TITLE
20180221 cleaningEMsection

### DIFF
--- a/src/ontology/simr-edit.owl
+++ b/src/ontology/simr-edit.owl
@@ -197,7 +197,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PLANA_0007552">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0007566"/>
-        <obo:IAO_0000115 rdf:resource=""/>
+        <obo:IAO_0000115 rdf:resource="http://purl.obolibrary.org/obo/simr.owl/"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-11-20T18:04:17Z</oboInOwl:creation_date>
         <rdfs:label xml:lang="en">sample preparation</rdfs:label>
@@ -311,6 +311,49 @@
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-12-20T20:28:28Z</oboInOwl:creation_date>
         <rdfs:label xml:lang="en">post submission</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PLANA_0007568 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PLANA_0007568">
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-02-21T17:23:48Z</oboInOwl:creation_date>
+        <rdfs:label xml:lang="en">no longer technologically relevant</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PLANA_0007569 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PLANA_0007569">
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-02-21T17:55:40Z</oboInOwl:creation_date>
+        <rdfs:label xml:lang="en">not a technology we use</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PLANA_0007570 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PLANA_0007570">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000007"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Panel of images from the same sample reflecting changes in a dimension.  For example: frames of a timelapse.</obo:IAO_0000115>
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-02-21T19:30:13Z</oboInOwl:creation_date>
+        <rdfs:label xml:lang="en">montage of images</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PLANA_0007572 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PLANA_0007572">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000020"/>
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-02-21T19:43:51Z</oboInOwl:creation_date>
+        <rdfs:label xml:lang="en">fixed samples</rdfs:label>
     </owl:Class>
     
 
@@ -1182,7 +1225,7 @@
     <!-- http://purl.obolibrary.org/obo/SIMR_0000022 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SIMR_0000022">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000020"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0007572"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000023"/>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbi:00000002</oboInOwl:hasDbXref>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIMR_terms</oboInOwl:hasOBONamespace>
@@ -1331,7 +1374,7 @@
     <!-- http://purl.obolibrary.org/obo/SIMR_0000035 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SIMR_0000035">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000020"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0007572"/>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbi:00000013</oboInOwl:hasDbXref>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIMR_terms</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cryofixed tissue</rdfs:label>
@@ -1342,7 +1385,7 @@
     <!-- http://purl.obolibrary.org/obo/SIMR_0000036 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SIMR_0000036">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000020"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0007572"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000037"/>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbi:00000015</oboInOwl:hasDbXref>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIMR_terms</oboInOwl:hasOBONamespace>
@@ -1454,7 +1497,7 @@
     <!-- http://purl.obolibrary.org/obo/SIMR_0000046 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SIMR_0000046">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000020"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0007572"/>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbi:00000026</oboInOwl:hasDbXref>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIMR_terms</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sectioned tissue</rdfs:label>
@@ -2360,7 +2403,7 @@
     <!-- http://purl.obolibrary.org/obo/SIMR_0000121 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SIMR_0000121">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000020"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0007572"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tissue treated to make cell membranes permeable, typically for the purpose of allowing access by exogenous stains or substrates.</obo:IAO_0000115>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jm</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2010-03-07T02:26:37Z</oboInOwl:creation_date>
@@ -2872,17 +2915,6 @@
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbi:00000227</oboInOwl:hasDbXref>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIMR_terms</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">grey scale graphic</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/SIMR_0000166 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SIMR_0000166">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000161"/>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbi:00000228</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIMR_terms</oboInOwl:hasOBONamespace>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">camera lucida assisted graphic</rdfs:label>
     </owl:Class>
     
 
@@ -4144,7 +4176,7 @@
     <!-- http://purl.obolibrary.org/obo/SIMR_0000234 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SIMR_0000234">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000228"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0007569"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jm</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2010-03-09T10:46:27Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbi:00000275</oboInOwl:hasDbXref>
@@ -4362,7 +4394,7 @@
     <!-- http://purl.obolibrary.org/obo/SIMR_0000250 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SIMR_0000250">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000246"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0007568"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jm</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2010-03-09T11:33:49Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbi:00000298</oboInOwl:hasDbXref>
@@ -4375,7 +4407,7 @@
     <!-- http://purl.obolibrary.org/obo/SIMR_0000251 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SIMR_0000251">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000246"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0007568"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jm</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2010-03-09T11:33:49Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbi:00000299</oboInOwl:hasDbXref>
@@ -4479,7 +4511,7 @@
     <!-- http://purl.obolibrary.org/obo/SIMR_0000259 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SIMR_0000259">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000230"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0007569"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jm</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2010-03-09T03:11:47Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbi:00000314</oboInOwl:hasDbXref>
@@ -4933,7 +4965,7 @@
     <!-- http://purl.obolibrary.org/obo/SIMR_0000289 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SIMR_0000289">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000221"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0007569"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jm</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2010-03-09T10:19:35Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbi:00000348</oboInOwl:hasDbXref>
@@ -5179,7 +5211,7 @@
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000303"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000194"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000018"/>
@@ -5284,7 +5316,7 @@
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000182"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0007569"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000018"/>
@@ -5310,7 +5342,7 @@
     <!-- http://purl.obolibrary.org/obo/SIMR_0000310 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SIMR_0000310">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000182"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0007569"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">optical coherence tomography; an interferometric method of imaging using back-scattered photons (elastic scattering)</obo:IAO_0000115>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jm</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2010-03-11T10:32:19Z</oboInOwl:creation_date>
@@ -8104,7 +8136,7 @@
     <!-- http://purl.obolibrary.org/obo/SIMR_0000521 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SIMR_0000521">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000020"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0007572"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jm</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2010-09-04T11:49:25Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbi:00000609</oboInOwl:hasDbXref>
@@ -8156,7 +8188,7 @@
     <!-- http://purl.obolibrary.org/obo/SIMR_0000525 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SIMR_0000525">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000246"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0007568"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jm</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2011-05-23T09:49:58Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbi:00000613</oboInOwl:hasDbXref>
@@ -8320,7 +8352,7 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000538"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sofia Robb</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-11-14T21:56:48Z</oboInOwl:creation_date>
-        <rdfs:label xml:lang="en">laborary animal services</rdfs:label>
+        <rdfs:label xml:lang="en">laboratory animal services</rdfs:label>
     </owl:Class>
     
 
@@ -8364,7 +8396,7 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000538"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sofia Robb</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-11-14T21:57:11Z</oboInOwl:creation_date>
-        <rdfs:label xml:lang="en">electron micorscopy</rdfs:label>
+        <rdfs:label xml:lang="en">electron microscopy</rdfs:label>
     </owl:Class>
     
 
@@ -8408,7 +8440,7 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SIMR_0000538"/>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sofia Robb</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-11-14T21:57:32Z</oboInOwl:creation_date>
-        <rdfs:label xml:lang="en">microscopy</rdfs:label>
+        <rdfs:label xml:lang="en">light microscopy</rdfs:label>
     </owl:Class>
     
 


### PR DESCRIPTION
removed camera lucida assisted graphic as it is an outdated method tomake a graphic and would not pertain to current institute work flows

started new folder entitled “no longer technologically relevant” to dump
old terms like the detectors not based in CCD or CMOS technology…

started new folder for technology we do not have (or are likely to in
the next five years) such as a neutron microscope.

added montage of images to reflect stills of a timelapse etc.

sample prep changed some structure. created fixed sample parent class
to parallel construction match unfixed category.